### PR TITLE
Fix haddock rendering

### DIFF
--- a/src/System/SysInfo.hsc
+++ b/src/System/SysInfo.hsc
@@ -26,12 +26,10 @@ import Foreign.Marshal.Alloc
 
 -- $usage
 --
--- @
--- λ> import System.SysInfo
--- λ> val <- sysInfo
--- λ> either (\_ -> "sysinfo failed") show val
--- "SysInfo {uptime = 121149, loads = Loads {sloads = [91200,80736,82592]}, totalram = 12286611456, freeram = 967655424, sharedram = 63033344, bufferram = 838983680, totalswap = 8261726208, freeswap = 8259276800, procs = 418, totalhigh = 0, freehigh = 0, memUnit = 1}"
--- @
+-- > λ> import System.SysInfo
+-- > λ> val <- sysInfo
+-- > λ> either (\_ -> "sysinfo failed") show val
+-- > "SysInfo {uptime = 121149, loads = Loads {sloads = [91200,80736,82592]}, totalram = 12286611456, freeram = 967655424, sharedram = 63033344, bufferram = 838983680, totalswap = 8261726208, freeswap = 8259276800, procs = 418, totalhigh = 0, freehigh = 0, memUnit = 1}"
 
 #if __GLASGOW_HASKELL__ < 800
 #let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)


### PR DESCRIPTION
Previously the backslash in the lambda expression was not showing up in the generated Haddock HTML. This fixes that.